### PR TITLE
fix!: keep casing when looking up layers in tenk config file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "typescript.tsdk": "node_modules/typescript/lib"
-}

--- a/packages/cli/src/entities/Layer/Layer.ts
+++ b/packages/cli/src/entities/Layer/Layer.ts
@@ -47,7 +47,7 @@ export class Layer implements Factory {
       if (starConfig) {
         this.applyConfig(starConfig);
       }
-      const layerConfig = config.layers[this.name.toLowerCase()];
+      const layerConfig = config.layers[this.name];
       if (layerConfig) {
         this.applyConfig(layerConfig);
       }

--- a/packages/cli/src/entities/Layer/__tests__/create.test.ts
+++ b/packages/cli/src/entities/Layer/__tests__/create.test.ts
@@ -87,6 +87,28 @@ describe("Layer.create", () => {
     });
   });
 
+  describe('layer config respects casing', () => {
+    const config = {
+      layers: {
+        test: {
+          odds: 0.5,
+          mustAccompany: {
+            "*": ["some other layer"],
+          },
+        },
+      },
+    };
+
+    beforeEach(() => {
+      layer.applyConfig = jest.fn();
+      layer.create('01_TeSt#10', config);
+    });
+
+    it("does not call applyConfig", () => {
+      expect(layer.applyConfig).not.toBeCalled();
+    });
+  })
+
   describe("with * config", () => {
     const config = {
       layers: {


### PR DESCRIPTION
- BREAKING CHANGE: remove lowercase caste when getting layer config from name